### PR TITLE
Disable auto update checks of zsh

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -24,7 +24,7 @@ ZSH_THEME="robbyrussell"
 # HYPHEN_INSENSITIVE="true"
 
 # Uncomment the following line to disable bi-weekly auto-update checks.
-# DISABLE_AUTO_UPDATE="true"
+DISABLE_AUTO_UPDATE="true"
 
 # Uncomment the following line to automatically update without prompting.
 # DISABLE_UPDATE_PROMPT="true"


### PR DESCRIPTION
Set the DISABLE_AUTO_UPDATE to true in the .zshrc config to prevent ZSH
from trying to update automatically. Instead it should be updated using
chezmoi.